### PR TITLE
fix: make error handle unknown types

### DIFF
--- a/src/account.rs
+++ b/src/account.rs
@@ -84,7 +84,7 @@ pub struct MasterAccountProfile {
     // pub name: ???
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[allow(missing_docs)]
 pub struct Account {
@@ -143,7 +143,7 @@ pub struct UpdateAccount {
 }
 
 /// See [Account Status](https://docs.sendwyre.com/docs/account-resource#account-status)
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum AccountStatus {
     /// Waiting on action from you or the Account holder. This is the initial
@@ -177,7 +177,7 @@ pub enum AccountType {
 }
 
 /// See [Account Fields](https://docs.sendwyre.com/docs/account-resource#account-fields)
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ProfileField {
     /// The specific datapoint encapsulated by the field.

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,70 +34,73 @@ impl Display for Error {
 pub struct ApiError {
     /// A unique identifier for this exception. This is very helpful when
     /// contacting support.
-    exception_id: String,
+    pub exception_id: String,
 
-    /// The category of the exception.
+    /// The category of the exception. See [`exception`] module.
     #[serde(rename = "type")]
-    kind: ApiErrorKind,
+    pub kind: String,
 
     /// A more granular specification than `type`.
-    error_code: Option<String>,
+    pub error_code: Option<String>,
 
     /// A human-friendly description of the problem.
-    message: String,
+    pub message: String,
 
     /// Indicates the language of the exception message.
-    language: String,
+    pub language: String,
 
     /// In rare cases, an exception may signal `true` here to indicate a
     /// transient problem. This means the request can be safely re-attempted.
-    transient: bool,
+    pub transient: bool,
 }
 
 /// See [Error Types](https://docs.sendwyre.com/docs/errors#error-types)
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
-pub enum ApiErrorKind {
+pub mod exception {
     /// The action failed due to problems with the request.
-    ValidationException,
+    pub const VALIDATION: &str = "ValidationException";
 
     /// A value was invalid.
-    InvalidValueException,
+    pub const INVALID_VALUE: &str = "InvalidValueException";
 
     /// A required field was missing.
-    FieldRequiredException,
+    pub const FIELD_REQUIRED: &str = "FieldRequiredException";
 
     /// You requested the use of more funds in the specified currency than were
     /// available.
-    InsufficientFundsException,
+    pub const INSUFFICIENT_FUNDS: &str = "InsufficientFundsException";
 
     /// You lack sufficient privilege to perform the requested action.
-    AccessDeniedException,
+    pub const ACCESS_DENIED: &str = "AccessDeniedException";
 
     /// There was a problem completing your transfer request.
-    TransferException,
+    pub const TRANSFER: &str = "TransferException";
 
     /// An MFA action is required to complete the request. In general you
     /// should not get this exception while using API keys.
-    MFARequiredException,
+    pub const MFA_REQUIRED: &str = "MFARequiredException";
 
     /// Please contact us at support@sendwyre.com to resolve this!
-    CustomerSupportException,
+    pub const CUSTOMER_SUPPORT: &str = "CustomerSupportException";
 
     /// You referenced something that could not be located.
-    NotFoundException,
+    pub const NOT_FOUND: &str = "NotFoundException";
 
     /// Your requests have exceeded your usage restrictions. Please contact us
     /// if you need this increased.
-    RateLimitException,
+    pub const RATE_LIMIT: &str = "RateLimitException";
 
     /// The account has had a locked placed on it for potential fraud reasons.
     /// The customer should [contact Wyre support](https://support.sendwyre.com/hc/en-us)
     /// for follow-up.
-    AccountLockedException,
+    pub const ACCOUNT_LOCKED: &str = "AccountLockedException";
 
     /// The account or IP has been blocked due to detected malicious behavior.
-    LockoutException,
+    pub const LOCKOUT: &str = "LockoutException";
 
     /// A problem with our services internally. This should rarely happen.
-    UnknownException,
+    pub const UNKNOWN: &str = "UnknownException";
+
+    /// The account has not been approved and cannot submit transactions.
+    pub const ACCOUNT_HAS_NOT_BEEN_APPROVED_TO_TRANSACT: &str =
+        "AccoutHasNotBeenApprovedToTransactException";
 }


### PR DESCRIPTION
The Wyre documentation implies there is a fixed set of error types, but
the documented list is non-exhaustive. We've encountered at least two
error types that are not on the list, and there are likely more. This
commit avoids the problem by using a `String` instead of an `enum` so it
can vacuously accept any error type. For matching and documentation's
sake we still include the known error types as consts.

This also addresses a semi-related issue, where the `ApiError` fields
were private. They need to be public so the error can be inspected and
handled properly.

This also adds the `Serialize` trait to a few types to aid in debugging.